### PR TITLE
Changed Nillion node ID generation and Nillion API port

### DIFF
--- a/services/nillion-interactor/README.md
+++ b/services/nillion-interactor/README.md
@@ -21,7 +21,7 @@ For local development, don't forget to:
 
 To provide a 23andMe dataset to the API to register secrets as appripriate on the Nillion network, run:
 
-`curl -i -X PUT -F "file=@testdata/hu278AF5_20210124151934.txt" http://127.0.0.1:5000/dataset`
+`curl -i -X PUT -F "file=@testdata/hu278AF5_20210124151934.txt" http://127.0.0.1:8732/dataset`
 
 This will return Nillion store IDs for all the SNPs of interest:
 
@@ -44,7 +44,7 @@ This will return Nillion store IDs for all the SNPs of interest:
 
 To run a Nillion computation to fetch a genomic result, run the following and provide a store ID from above corresponding to the SNP of interest. For example, for evaluating thrombosis we care about the SNP rs6025:
 
-`curl -i -X POST http://127.0.0.1:5000/computations/thrombosis -H "Content-Type: application/json" -d '{"store_id": "87253aa0-d93b-4897-aad2-689c270134e1"}'`
+`curl -i -X POST http://127.0.0.1:8732/computations/thrombosis -H "Content-Type: application/json" -d '{"store_id": "87253aa0-d93b-4897-aad2-689c270134e1"}'`
 
 This will return a result of either 0 or 1, with the former corresponding to the absence of disease risk and the latter corresponding to the presence of diasease risk. 
 

--- a/services/nillion-interactor/nadatest.py
+++ b/services/nillion-interactor/nadatest.py
@@ -4,6 +4,8 @@ import os
 import sys
 import pytest
 
+import socket
+
 from dotenv import load_dotenv
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
@@ -15,10 +17,17 @@ load_dotenv()
 
 # 1 Party running simple addition on 1 stored secret and 1 compute time secret
 async def main():
-    cluster_id = os.getenv("NILLION_CLUSTER_ID")
+    def get_random_node_key():
+        hostname = socket.gethostname()
+        ip_address = socket.gethostbyname(hostname)
+        result = hostname + "_" + ip_address
+        print("Node key: ", result)
+        return result
+    
     userkey = getUserKeyFromFile(os.getenv("NILLION_USERKEY_PATH_PARTY_1"))
-    nodekey = getNodeKeyFromFile(os.getenv("NILLION_NODEKEY_PATH_PARTY_1"))
+    nodekey = nillion.NodeKey.from_seed(get_random_node_key())
     client = create_nillion_client(userkey, nodekey)
+    cluster_id = os.getenv("NILLION_CLUSTER_ID")
     party_id = client.party_id()
     user_id = client.user_id()
     party_name = "Party1"


### PR DESCRIPTION
This PR fixes an issue which previously made the Nillion API inoperable. 

Keeping a fixed node ID lead to constant timeouts. According to the Nillion team, this was due to the network (specifically libp2p) getting "confused" about where to respond. 

Instead of fully randomizing node IDs, this PR attempts to keep node IDs fixed per host so state isn't blown away frequently. 

Nillion client instances are also kept persistent per API session for better performance. 

Finally, the listening port for the API has been changed to avoid conflicts with MacOS services. 