### PR TITLE
Added CORS handling and changed Nillion node key generation

### DIFF
--- a/services/nillion-interactor/app.py
+++ b/services/nillion-interactor/app.py
@@ -1,11 +1,14 @@
 import asyncio
 from flask import Flask, request, jsonify
+from flask_cors import CORS
 import os
 import py_nillion_client as nillion
 import sys
 import werkzeug
 
 import socket
+import random
+import string
 
 from dotenv import load_dotenv
 
@@ -16,11 +19,14 @@ from helpers.nillion_keypath_helper import getUserKeyFromFile, getNodeKeyFromFil
 load_dotenv()
 
 app = Flask(__name__)
+CORS(app, resources={r"/*": {"origins": "*"}})
 
 def get_random_node_key():
-        hostname = socket.gethostname()
-        ip_address = socket.gethostbyname(hostname)
-        result = hostname + "_" + ip_address
+        # hostname = socket.gethostname()
+        # ip_address = socket.gethostbyname(hostname)
+        # result = hostname + "_" + ip_address
+        chars = string.ascii_letters + string.digits
+        result = ''.join(random.choice(chars) for i in range(10))
         print("Node key: ", result)
         return result
 

--- a/services/nillion-interactor/nadatest.py
+++ b/services/nillion-interactor/nadatest.py
@@ -6,6 +6,9 @@ import pytest
 
 import socket
 
+import random
+import string
+
 from dotenv import load_dotenv
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
@@ -18,9 +21,11 @@ load_dotenv()
 # 1 Party running simple addition on 1 stored secret and 1 compute time secret
 async def main():
     def get_random_node_key():
-        hostname = socket.gethostname()
-        ip_address = socket.gethostbyname(hostname)
-        result = hostname + "_" + ip_address
+        # hostname = socket.gethostname()
+        # ip_address = socket.gethostbyname(hostname)
+        # result = hostname + "_" + ip_address
+        chars = string.ascii_letters + string.digits
+        result = ''.join(random.choice(chars) for i in range(10))
         print("Node key: ", result)
         return result
     

--- a/services/nillion-interactor/requirements.txt
+++ b/services/nillion-interactor/requirements.txt
@@ -3,3 +3,4 @@ nada-dsl>=0.0.7
 py-nillion-client>=0.0.7
 pytest-asyncio>=0.23.6
 Flask[async]==3.0.3
+flask-cors==4.0.0


### PR DESCRIPTION
This PR fixes two bugs reported by @Aeesh:
- The Nillion API now supports CORS handling
- The Nillion API now uses our original scheme to derive node ID, i.e. random generation on each startup. The downside is Nillion state is reset with each restart. 