### PR TITLE
Ensuring the Sign Protocol API actually returns a result

### DIFF
--- a/services/sign-protocol-interactor/README.md
+++ b/services/sign-protocol-interactor/README.md
@@ -11,8 +11,9 @@ The Sign Protocol API allows for the creation of VerifiedTrait attestations tail
 1. Clone the repository.
 2. Navigate to the `services/sign-protocol-interactor` directory.
 3. Install dependencies by running `npm install`.
-4. Start the server by running `npm start`.
-5. Send a POST request to `http://localhost:3000/sign/VerifiedTrait` with the following JSON payload using curl:
+4. Build the project by running `npm run build`
+5. Start the server by running `npm run start`.
+6. Send a POST request to `http://localhost:3000/sign/VerifiedTrait` with the following JSON payload using curl:
    ```bash
    curl -X POST \
      -H "Content-Type: application/json" \

--- a/services/sign-protocol-interactor/src/app.ts
+++ b/services/sign-protocol-interactor/src/app.ts
@@ -43,10 +43,9 @@ app.post('/sign/VerifiedTrait', async (req: Request, res: Response) => {
       data: schemaData,
       indexingValue:passport_id,
       recipients: [config.signer], // The signer's address.
-  });
-  console.log('tx', tx);
-  return tx;
-    
+    });
+    console.log('tx', tx);
+    res.status(200).json(tx);
   } catch (error) {
     console.error('Error creating attestation:', error);
     if (error instanceof Error) {


### PR DESCRIPTION
The Sign Protocol API did not return the results of successful transactions to the user. 

This PR ensures that the output is returned successfully. 