### PR TITLE
Fixed bug with the way params were being read in the Sign  Protocol API

### DIFF
--- a/services/sign-protocol-interactor/src/app.ts
+++ b/services/sign-protocol-interactor/src/app.ts
@@ -22,7 +22,7 @@ app.use(express.json());
 
 app.post('/sign/VerifiedTrait', async (req: Request, res: Response) => {
   try {
-    const { passport_id, provider, trait, value }: VerifiedTraitRequest = req.body;
+    const { passport_id, provider, trait, value }: VerifiedTraitRequest = req.params;
 
     const PRIVATE_KEY: typeof PrivateKey = config.privateKey as typeof PrivateKey;
     const account = privateKeyToAccount(PRIVATE_KEY);


### PR DESCRIPTION
The Sign Protocol API doesn't actually read request parameters and publishes empty attestations. 

This PR attempts to fix this issue.