### PR TITLE
Made Sign Protocol API compatible with DO builds

### DIFF
--- a/mtDog/lib/host/src/app.rs
+++ b/mtDog/lib/host/src/app.rs
@@ -116,7 +116,7 @@ impl TemplateApp {
             let result = Client::new()
                     .post(UPLOAD_URL)            
                     .body(body)                    
-                    .header("contentType", "application/json; charset=utf-8")
+                    .header("Content-Type", "application/json")
                     .header("Accept", "application/json")                    
                     .send();                    
             match result {

--- a/services/sign-protocol-interactor/README.md
+++ b/services/sign-protocol-interactor/README.md
@@ -15,7 +15,5 @@ The Sign Protocol API allows for the creation of VerifiedTrait attestations tail
 5. Start the server by running `npm run start`.
 6. Send a POST request to `http://localhost:3000/sign/VerifiedTrait` with the following JSON payload using curl:
    ```bash
-   curl -X POST \
-     -H "Content-Type: application/json" \
-     -d '{"passport_id": "123456789", "provider": "Mt-Dog", "trait": "custom_trait", "value": "custom_value"}' \
-     http://localhost:3000/sign/VerifiedTrait
+   curl -i -X POST -H "Content-Type: application/json" -d '{"passport_id": "123456789", "provider": mtDog", "trait": "custom_trait", "value": "custom_value"}' http://localhost:3000/sign/VerifiedTrait
+   ```

--- a/services/sign-protocol-interactor/src/app.ts
+++ b/services/sign-protocol-interactor/src/app.ts
@@ -22,7 +22,9 @@ app.use(express.json());
 
 app.post('/sign/VerifiedTrait', async (req: Request, res: Response) => {
   try {
-    const { passport_id, provider, trait, value }: VerifiedTraitRequest = req.params;
+    const { passport_id, provider, trait, value }: VerifiedTraitRequest = req.body as unknown as VerifiedTraitRequest;
+
+    console.log("Incoming request: ", passport_id, provider, trait, value)
 
     const PRIVATE_KEY: typeof PrivateKey = config.privateKey as typeof PrivateKey;
     const account = privateKeyToAccount(PRIVATE_KEY);


### PR DESCRIPTION
- See title
- Additionally, reverted to using request.body as it makes more sense. mtDog will have to be adjusted accordingly. 