### PR TITLE
Fix File Progress State on Firefox

### DIFF
--- a/monadic-dna-portal/src/components/fileProgressDetails.tsx
+++ b/monadic-dna-portal/src/components/fileProgressDetails.tsx
@@ -27,7 +27,7 @@ const FileProgressDetails = ({
                     <UploadFileIcon className='w-10 h-10' />
                     <div>
                         <Typography color='text.primary'> { file.name } </Typography>
-                        <Typography color='text.secondary' variant='subtitle2'> {formatFileSize(file.size ?? 0)} .{ `${fileProgress < 100 ? 'Loading' : 'Complete' }` }</Typography>
+                        <Typography color='text.secondary' variant='subtitle2'> {formatFileSize(file.size ?? 0)} . { `${fileProgress < 100 ? 'Loading' : 'Complete' }` }</Typography>
                         <Box sx={{ width: '200px' }}>
                             <LinearProgress variant='determinate' value={fileProgress} />
                         </Box>

--- a/monadic-dna-portal/src/components/uploadFile.tsx
+++ b/monadic-dna-portal/src/components/uploadFile.tsx
@@ -54,6 +54,7 @@ const UploadFile = ({ type, isTypeCreate }: { type: ActionType; isTypeCreate?: b
 
             const reader = new FileReader();
             reader.onprogress = updateProgress;
+            reader.onloadend = updateProgress;
             reader.readAsArrayBuffer(selectedFile);
         }
 
@@ -231,12 +232,12 @@ const UploadFile = ({ type, isTypeCreate }: { type: ActionType; isTypeCreate?: b
                     <div>
                         <Link
                             className='p-0 cursor-pointer'
-                            component="label"
+                            component='label'
                             variant='inherit'
                             color='text.primary'
                         >
                             Click to upload
-                            <VisuallyHiddenInput type="file" onChange={handleFileChange} disabled={isFileLoading} />
+                            <VisuallyHiddenInput type='file' accept='.txt' onChange={handleFileChange} disabled={isFileLoading} />
                         </Link>
                         {' '}
                         or drag and drop

--- a/monadic-dna-portal/src/components/uploadFile.tsx
+++ b/monadic-dna-portal/src/components/uploadFile.tsx
@@ -61,6 +61,7 @@ const UploadFile = ({ type, isTypeCreate }: { type: ActionType; isTypeCreate?: b
         if(currentAction.type === 'viewResults') {
             const reader = new FileReader();
             reader.onprogress = updateProgress;
+            reader.onloadend = updateProgress;
 
             reader.onload = (e: ProgressEvent<FileReader>) => {
                 try {
@@ -237,7 +238,7 @@ const UploadFile = ({ type, isTypeCreate }: { type: ActionType; isTypeCreate?: b
                             color='text.primary'
                         >
                             Click to upload
-                            <VisuallyHiddenInput type='file' accept='.txt' onChange={handleFileChange} disabled={isFileLoading} />
+                            <VisuallyHiddenInput type='file' accept={currentAction.acceptedFileFormats} onChange={handleFileChange} disabled={isFileLoading} />
                         </Link>
                         {' '}
                         or drag and drop

--- a/monadic-dna-portal/src/types/uploadFile.ts
+++ b/monadic-dna-portal/src/types/uploadFile.ts
@@ -5,6 +5,7 @@ export interface IActionData {
     title: string;
     buttonTitle: string;
     buttonAction: string;
+    acceptedFileFormats: string;
 }
 
 export const ActionData: Record<ActionType, IActionData> = {
@@ -12,13 +13,15 @@ export const ActionData: Record<ActionType, IActionData> = {
         title: 'Upload Raw DNA File',
         buttonTitle: 'Create DNA PAssport',
         buttonAction: 'createDNAPassport',
-        type: 'createPassport'
+        type: 'createPassport',
+        acceptedFileFormats: '.txt'
     },
     'viewResults': {
         title: 'Upload Your DNA Passport',
         buttonTitle: 'View Results',
         buttonAction: 'viewResults',
-        type: 'viewResults'
+        type: 'viewResults',
+        acceptedFileFormats: '.json'
     }
 }
 

--- a/monadic-dna-portal/src/utils/index.ts
+++ b/monadic-dna-portal/src/utils/index.ts
@@ -19,6 +19,9 @@ export function generateRandomUID(digits: number): number {
 export const parsePassportFile = (fileContent: string) => {
     try {
         const jsonContent = JSON.parse(fileContent) as IMonadicDNAPassport;
+        if (!isValidMonadicDNAPassport(jsonContent)) {
+            throw new Error('Parsed JSON content does not match IMonadicDNAPassport interface');
+        }
         return jsonContent;
     } catch (error) {
         console.error('Error parsing JSON file:', error);
@@ -50,3 +53,17 @@ export const getValue = (data: string) => {
         return data;
     }
 }
+
+export const isValidMonadicDNAPassport = (jsonContent: any): jsonContent is IMonadicDNAPassport => {
+    const { passport_id, filename_hash, data_hash, nillion_data } = jsonContent;
+
+    return (
+        typeof passport_id === 'string' &&
+        typeof filename_hash === 'string' &&
+        typeof data_hash === 'string' &&
+        typeof nillion_data === 'object' &&
+        !Array.isArray(nillion_data) &&
+        Object.keys(nillion_data).length !== 0 &&
+        Object.values(nillion_data).every(value => typeof value === 'string')
+    );
+};

--- a/snipper-bot/src/components/fileProgressIndicator.tsx
+++ b/snipper-bot/src/components/fileProgressIndicator.tsx
@@ -11,10 +11,12 @@ import { formatFileSize } from '@/utils';
 
 const FileProgressIndicator = ({
     file,
-    fileProgress
+    fileProgress,
+    handleClickDeleteFile
 }: {
     file: File;
     fileProgress: number;
+    handleClickDeleteFile: () => void;
 }) => {
   return (
     <>
@@ -23,14 +25,14 @@ const FileProgressIndicator = ({
               <UploadFileIcon className='w-10 h-10' />
               <div>
                   <Typography color='text.primary'> { file.name } </Typography>
-                  <Typography color='text.secondary' variant='subtitle2'> {formatFileSize(file?.size ?? 0)} . Loading </Typography>
+                  <Typography color='text.secondary' variant='subtitle2'> {formatFileSize(file.size ?? 0)} . { `${fileProgress < 100 ? 'Loading' : 'Complete' }` }</Typography>
                   <Box sx={{ width: '200px' }}>
                       <LinearProgress variant='determinate' value={fileProgress} />
                   </Box>
               </div>
           </div>
           <IconButton
-              onClick={() => console.log('delete file')}
+              onClick={handleClickDeleteFile}
               aria-label="remove file"
           >
               <DeleteIcon />

--- a/snipper-bot/src/components/uploadFile.tsx
+++ b/snipper-bot/src/components/uploadFile.tsx
@@ -19,6 +19,7 @@ import AnalysisInsights from './analysisInsights';
 import AnalysisStepper from './analysisStepper';
 import ErrorModal from './errorModal';
 import { CustomError, invalidFileError } from '@/types/customError';
+import { isValidMonadicDNAPassport } from '@/utils';
 
 const config = require('../config.json');
 
@@ -44,6 +45,7 @@ const UploadFile = () => {
             const reader = new FileReader();
             reader.onprogress = updateProgress;
             reader.onload = parseFile;
+            reader.onloadend = updateProgress;
             reader.readAsText(selectedFile);
         }
     };
@@ -61,6 +63,9 @@ const UploadFile = () => {
         const fileContent = e.target?.result as string;
         try {
             const jsonContent = JSON.parse(fileContent) as IMonadicDNAPassport;
+            if (!isValidMonadicDNAPassport(jsonContent)) {
+                throw new Error('Parsed JSON content does not match IMonadicDNAPassport interface');
+            }
             setPassport(jsonContent);
             setActiveStep((prevActiveStep) => prevActiveStep + 1);
           } catch (e) {
@@ -70,10 +75,7 @@ const UploadFile = () => {
     };
 
     const analyseData = async() => {
-        if (!passport?.nillion_data) {
-          setError(invalidFileError);
-          return
-        };
+        if (!passport) { return };
 
         setIsProcessingTransaction(true);
 
@@ -131,6 +133,12 @@ const UploadFile = () => {
         );
     }
 
+    const handleClickDeleteFile = () => {
+        setFile(null);
+        setFileProgress(0);
+        setIsFileLoading(false);
+    }
+
     return (
         <Box className='pt-4 sm:pt-11'>
             {error && <ErrorModal error={error} setError={setError} /> }
@@ -157,7 +165,7 @@ const UploadFile = () => {
                             color='text.primary'
                         >
                             Click to upload
-                            <VisuallyHiddenInput type='file' onChange={handleFileChange} disabled={isFileLoading} />
+                            <VisuallyHiddenInput type='file' accept='.json' onChange={handleFileChange} disabled={isFileLoading} />
                         </Link>
                         {' '}
                         or drag and drop
@@ -166,7 +174,7 @@ const UploadFile = () => {
                     <Typography color='text.secondary'> DNA Passport JSON </Typography>
                 </Box>
                 {file &&
-                    <FileProgressIndicator {...{file, fileProgress}} />
+                    <FileProgressIndicator {...{file, fileProgress, handleClickDeleteFile}} />
                 }
 
                 <AnalysisInsights />
@@ -174,7 +182,7 @@ const UploadFile = () => {
                 <LoadingButton
                     variant='contained'
                     loading={isProcessingTransaction}
-                    disabled={fileProgress < 100}
+                    disabled={fileProgress < 100 || !passport}
                     onClick={() => analyseData()}
                     className={`w-full sm:w-[400px] ${file ? 'mt-8' : 'mt-20' }`}
                 >

--- a/snipper-bot/src/utils/index.ts
+++ b/snipper-bot/src/utils/index.ts
@@ -53,6 +53,7 @@ export const isValidMonadicDNAPassport = (jsonContent: any): jsonContent is IMon
         typeof data_hash === 'string' &&
         typeof nillion_data === 'object' &&
         !Array.isArray(nillion_data) &&
+        Object.keys(nillion_data).length !== 0 &&
         Object.values(nillion_data).every(value => typeof value === 'string')
     );
 };

--- a/snipper-bot/src/utils/index.ts
+++ b/snipper-bot/src/utils/index.ts
@@ -43,3 +43,16 @@ export const getValue = (data: string) => {
         return data;
     }
 }
+
+export const isValidMonadicDNAPassport = (jsonContent: any): jsonContent is IMonadicDNAPassport => {
+    const { passport_id, filename_hash, data_hash, nillion_data } = jsonContent;
+
+    return (
+        typeof passport_id === 'string' &&
+        typeof filename_hash === 'string' &&
+        typeof data_hash === 'string' &&
+        typeof nillion_data === 'object' &&
+        !Array.isArray(nillion_data) &&
+        Object.values(nillion_data).every(value => typeof value === 'string')
+    );
+};


### PR DESCRIPTION
This PR addresses an [issue](#58) where the onprogress event is triggered only once during file upload in Firefox, leading to inaccurate progress updates. To resolve this issue, the file progress is now updated upon the `onloadend` event instead of relying solely on the `onprogress` event. This ensures consistent and accurate progress tracking across different browsers, including Firefox.

Additionally, this PR validates the uploaded json file in the `snipper-bot` app to match the expected monadicDNA passport interface.






https://github.com/Cryptonomic/MonadicDNA/assets/47456520/e61592fe-19c1-4c50-a65d-fbc544b5bb49

