### PR TITLE
Implemented multi-core support for faster execution 

### DIFF
--- a/zama-poc/Cargo.lock
+++ b/zama-poc/Cargo.lock
@@ -809,5 +809,6 @@ dependencies = [
  "chrono",
  "env_logger",
  "log",
+ "rayon",
  "tfhe",
 ]

--- a/zama-poc/Cargo.toml
+++ b/zama-poc/Cargo.toml
@@ -8,5 +8,6 @@ edition = "2021"
 [dependencies]
 chrono = "0.4.38"
 env_logger = "0.11.3"
+rayon = "1.5"
 log = "0.4.22"
-tfhe = { version = "0.7.1", features = [ "boolean", "shortint", "integer", "aarch64-unix" ] }
+tfhe = { version = "0.7.1", features = [ "boolean", "shortint", "integer", "x86_64-unix" ] }


### PR DESCRIPTION
Used `rayon` crate to perform parallel execution across all **threads**. 

On **single** thread :

```
2024-07-15 23:49:24 [INFO] - Hello, Zama!
2024-07-15 23:49:24 [INFO] - Setting up Zama env
2024-07-15 23:49:24 [INFO] - Number of lines to process: 1000000
2024-07-15 23:49:25 [INFO] - Lines of processed data: 553190
2024-07-15 23:51:39 [INFO] - Lines of encrypted data: 553190
2024-07-15 23:51:39 [INFO] - Lookup result: true
2024-07-15 23:51:39 [INFO] - Lookup result: false
2024-07-15 23:53:53 [INFO] - Genotype frequencies: {9: 9021, 10: 81789, 7: 39357, 4: 341, 2: 9106, 5: 139432, 3: 39307, 0: 12358, 1: 81948, 6: 711, 8: 139820}
2024-07-15 23:53:53 [INFO] - run_iteration took: 269.620158125s
2024-07-15 23:53:53 [INFO] - Bye, Zama!
```

Multi thread execution using `Rayon` crate: 

```
cargo run --release
   Compiling zama-poc v0.1.0 (/home/amardeep/MonadicDNA/zama-poc)
    Finished release [optimized] target(s) in 0.82s
     Running `target/release/zama-poc`
2024-07-22 15:40:15 [INFO] - Hello, Zama!
2024-07-22 15:40:15 [INFO] - Setting up Zama env
2024-07-22 15:40:16 [INFO] - Number of lines to process: 1000000
2024-07-22 15:40:16 [INFO] - Lines of processed data: 553190
2024-07-22 15:40:29 [INFO] - Lines of encrypted data: 553190
2024-07-22 15:40:29 [INFO] - Lookup result: true
2024-07-22 15:40:29 [INFO] - Lookup result: false
2024-07-22 15:40:42 [INFO] - Genotype frequencies: {10: 81789, 0: 12358, 2: 9106, 5: 139432, 4: 341, 9: 9021, 7: 39357, 6: 711, 1: 81948, 8: 139820, 3: 39307}
2024-07-22 15:40:42 [INFO] - run_iteration took: 26.91329741s
2024-07-22 15:40:42 [INFO] - Bye, Zama!
```

**10 times** improvement in execution.