### PR TITLE
Implemented multi-core support for faster execution

### DIFF
--- a/zama-poc/Cargo.lock
+++ b/zama-poc/Cargo.lock
@@ -809,5 +809,6 @@ dependencies = [
  "chrono",
  "env_logger",
  "log",
+ "rayon",
  "tfhe",
 ]

--- a/zama-poc/Cargo.toml
+++ b/zama-poc/Cargo.toml
@@ -8,5 +8,6 @@ edition = "2021"
 [dependencies]
 chrono = "0.4.38"
 env_logger = "0.11.3"
+rayon = "1.5"
 log = "0.4.22"
-tfhe = { version = "0.7.1", features = [ "boolean", "shortint", "integer", "aarch64-unix" ] }
+tfhe = { version = "0.7.1", features = [ "boolean", "shortint", "integer", "x86_64-unix" ] }

--- a/zama-poc/Cargo.toml
+++ b/zama-poc/Cargo.toml
@@ -13,23 +13,5 @@ rayon = "1.5"
 log = "0.4.22"
 
 tfhe = { version = "0.7.1", features = [ "boolean", "shortint", "integer", "x86_64-unix" ] }
-reqwest = { version = "0.11", features = ["json"] }
-rusqlite = { version = "0.26", features = ["bundled"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-tfhe = { version = "0.7.1", features = [ "boolean", "shortint", "integer", "aarch64-unix" ] }
-tokio = { version = "1", features = ["full"] }
 
-
-[[bin]]
-name = "main"
-path = "src/main.rs"
-
-[[bin]]
-name = "server"
-path = "src/server.rs"
-
-[[bin]]
-name = "client"
-path = "src/client.rs"
 

--- a/zama-poc/src/main.rs
+++ b/zama-poc/src/main.rs
@@ -7,19 +7,10 @@ use std::collections::HashMap;
 use std::time::Instant;
 use log::{info};
 use env_logger::{Builder, Env};
-
 use std::hash::{Hash, Hasher};
 use std::collections::hash_map::DefaultHasher;
 use rayon::prelude::*;
 use std::sync::{Arc, Mutex};
-
-
-mod genome_file_processing;
-mod zama_compute;
-mod server;
-mod client;
-
-
 fn main() {
     Builder::from_env(Env::default().default_filter_or("info"))
         .format(|buf, record| {
@@ -81,7 +72,7 @@ fn get_genotype_frequencies(
         .map(|(&key, value)| (key, value))
         .collect();
 
-    items.into_par_iter().for_each(|(_encoded_rsid, encrypted_genotype)| {
+    items.into_par_iter().for_each(|(encoded_rsid, encrypted_genotype)| {
         let decompressed_encrypted_genotype = encrypted_genotype.decompress();
         let decrypted_genotype = decompressed_encrypted_genotype.decrypt(&client_key);
 


### PR DESCRIPTION
Used `rayon` crate to perform parallel execution across all **threads**. 

On **single** thread :

```
2024-07-15 23:49:24 [INFO] - Hello, Zama!
2024-07-15 23:49:24 [INFO] - Setting up Zama env
2024-07-15 23:49:24 [INFO] - Number of lines to process: 1000000
2024-07-15 23:49:25 [INFO] - Lines of processed data: 553190
2024-07-15 23:51:39 [INFO] - Lines of encrypted data: 553190
2024-07-15 23:51:39 [INFO] - Lookup result: true
2024-07-15 23:51:39 [INFO] - Lookup result: false
2024-07-15 23:53:53 [INFO] - Genotype frequencies: {9: 9021, 10: 81789, 7: 39357, 4: 341, 2: 9106, 5: 139432, 3: 39307, 0: 12358, 1: 81948, 6: 711, 8: 139820}
2024-07-15 23:53:53 [INFO] - run_iteration took: 269.620158125s
2024-07-15 23:53:53 [INFO] - Bye, Zama!
```

**Multi thread** execution using `Rayon` crate: 

```
cargo run --release
   Compiling zama-poc v0.1.0 (/home/amardeep/MonadicDNA/zama-poc)
    Finished release [optimized] target(s) in 0.82s
     Running `target/release/zama-poc`
2024-07-22 15:40:15 [INFO] - Hello, Zama!
2024-07-22 15:40:15 [INFO] - Setting up Zama env
2024-07-22 15:40:16 [INFO] - Number of lines to process: 1000000
2024-07-22 15:40:16 [INFO] - Lines of processed data: 553190
2024-07-22 15:40:29 [INFO] - Lines of encrypted data: 553190
2024-07-22 15:40:29 [INFO] - Lookup result: true
2024-07-22 15:40:29 [INFO] - Lookup result: false
2024-07-22 15:40:42 [INFO] - Genotype frequencies: {10: 81789, 0: 12358, 2: 9106, 5: 139432, 4: 341, 9: 9021, 7: 39357, 6: 711, 1: 81948, 8: 139820, 3: 39307}
2024-07-22 15:40:42 [INFO] - run_iteration took: 26.91329741s
2024-07-22 15:40:42 [INFO] - Bye, Zama!
```

**10 times** improvement in execution.